### PR TITLE
Fix "Download the codemod" command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ cd path-to-your-project
 Download the codemod:
 
 ```
-curl https://github.com/zeit/next-codemod/archive/master.tar.gz | tar -xz --strip=2 next-codemod-master/transforms/url-to-withrouter.js
+curl -L https://github.com/zeit/next-codemod/archive/master.tar.gz | tar -xz --strip=2 next-codemod-master/transforms/url-to-withrouter.js
 ```
 
 Run the transformation:


### PR DESCRIPTION
When I'm trying to download the codemod with the command proposed, I get these errors :
```
tar: Unrecognized archive format
tar: next-codemod-master/transforms/url-to-withrouter.js: Not found in archive
tar: Error exit delayed from previous errors.
```

To fix it, I'm adding `-L` to the command :
```
curl -L https://github.com/zeit/next-codemod/archive/master.tar.gz | tar -xz --strip=2 next-codemod-master/transforms/url-to-withrouter.js
```

`-L`: All symbolic links will be followed.